### PR TITLE
Fix colorscheme change error

### DIFF
--- a/autoload/vm/themes.vim
+++ b/autoload/vm/themes.vim
@@ -24,7 +24,7 @@ fun! vm#themes#init()
   silent! hi clear VM_Insert
   silent! hi clear MultiCursor
 
-  if !empty(g:VM_highlight_matches)
+  if !empty(get(g:, 'VM_highlight_matches', ''))
     redir => out
     silent! highlight Search
     redir END


### PR DESCRIPTION
Changing themes was producing a `g:VM_highlight_matches` `undefined` error.