### PR TITLE
In README.md, use single quotes for vim-plug cmd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ And more... of course, you can enter insert mode and autocomplete will work.
 
 With vim-plug:
 
-    Plug "mg979/vim-visual-multi", {'branch': 'master'}
+    Plug 'mg979/vim-visual-multi', {'branch': 'master'}
 
 
 ### Documentation


### PR DESCRIPTION
When the plugin name is enclosed in double quotes, it's interpreted as a comment rather than an argument.

See https://github.com/junegunn/vim-plug/issues/33