### PR TITLE
Clear command line when VM_silent_exit is true

### DIFF
--- a/autoload/vm.vim
+++ b/autoload/vm.vim
@@ -165,7 +165,7 @@ fun! vm#reset(...)
     if !get(g:, 'VM_silent_exit', 0) && !a:0
         call s:V.Funcs.msg('Exited Visual-Multi.')
     else
-        call s:V.Funcs.msg('')
+        echo "\r"
     endif
 
     call vm#variables#reset_globals()

--- a/autoload/vm.vim
+++ b/autoload/vm.vim
@@ -164,6 +164,8 @@ fun! vm#reset(...)
     "exiting manually
     if !get(g:, 'VM_silent_exit', 0) && !a:0
         call s:V.Funcs.msg('Exited Visual-Multi.')
+    else
+        call s:V.Funcs.msg('')
     endif
 
     call vm#variables#reset_globals()


### PR DESCRIPTION
When the user have set VM_silent_exit = 1,  who will not want to press <Ctrl-l> to clear msg after exiting VM.