### PR TITLE
Add support for an auto-pairs fork

### DIFF
--- a/autoload/vm/comp.vim
+++ b/autoload/vm/comp.vim
@@ -8,7 +8,8 @@ let s:plugins = extend({
             \},
             \'AutoPairs': {
             \   'test': { -> exists('b:autopairs_enabled') && b:autopairs_enabled },
-            \   'enable': 'unlet b:autopairs_loaded | call AutoPairsTryInit() | let b:autopairs_enabled = 1',
+            \   'enable': 'unlet b:autopairs_loaded | if exists("*autopairs#AutoPairsTryInit") | '
+            \             . 'call autopairs#AutoPairsTryInit() | else | call AutoPairsTryInit() | endif | let b:autopairs_enabled = 1',
             \   'disable': 'let b:autopairs_enabled = 0',
             \},
             \'tagalong': {


### PR DESCRIPTION
I've (admittedly unofficially, because the author is so gone that they're not around to pick new maintainers) picked up [auto-pairs](https://github.com/jiangmiao/auto-pairs) ([forked repo](github.com/lunarWatcher/auto-pairs)) in the absence of its original author. This PR makes both variants compatible with vim-visual-multi.

To make a long story short here, I migrated the core of auto-pairs to be `autoload`ed, which means the fork has `autopairs#AutoPairsTryInit` instead of `AutoPairsTryInit`.

This is one of two proposals, for the record. Alternative B if this is too ugly is:

```
            \'AutoPairs': {
            \   'test': { -> exists('b:autopairs_enabled') && b:autopairs_enabled && !exists('g:AutoPairsVersion') },
            \   'enable': 'unlet b:autopairs_loaded | call AutoPairsTryInit() | let b:autopairs_enabled = 1',
            \   'disable': 'let b:autopairs_enabled = 0',
            \},
            \'AutoPairsFork': {
            \   'test': { -> exists('b:autopairs_enabled') && b:autopairs_enabled && exists('g:AutoPairsVersion') },
            \   'enable': 'unlet b:autopairs_loaded | call autopairs#AutoPairsTryInit() | let b:autopairs_enabled = 1',
            \   'disable': 'let b:autopairs_enabled = 0',
            \},
```


I do, however, have a hackish workaround that forwards AutoPairsTryInit() to the new function if vim-visual-multi is detected. It's therefore not critical that this is merged. Feel free to reject if this feels pointless.


