### PR TITLE
fix: rhs missing from maparg dict for lua-function neovim mappings

### DIFF
--- a/autoload/vm/maps.vim
+++ b/autoload/vm/maps.vim
@@ -259,12 +259,14 @@ fun! s:assign(plug, key, buffer, ...) abort
         let K = maparg(k, m, 0, 1)
         if !empty(K) && K.buffer
             let b = 'b'.bufnr('%').': '
+            " Handle Neovim mappings with Lua functions as rhs
+            let rhs = has_key(K, 'rhs') ? K.rhs : '<Lua function ' .. K.callback .. '>'
             if m != 'i'
-                let s = b.'Could not map: '.k.' ('.a:plug.')  ->  ' . K.rhs
+                let s = b.'Could not map: '.k.' ('.a:plug.')  ->  ' . rhs
                 call add(b:VM_Debug.lines, s)
                 return ''
             else
-                let s = b.'Overwritten imap: '.k.' ('.a:plug.')  ->  ' . K.rhs
+                let s = b.'Overwritten imap: '.k.' ('.a:plug.')  ->  ' . rhs
                 call add(b:VM_Debug.lines, s)
             endif
         endif


### PR DESCRIPTION
Closes #203.

I experienced the same problems as in #203 and after some debugging found that the error came from `s:assign` when trying to access `K.rhs` from the output or `maparg()`. This happens for mappings defined via  [vim.keymap.set()](https://neovim.io/doc/user/lua.html#vim.keymap.set()) with lua function as rhs, e.g. for me `maparg('gc', 'n', 0, 1)` gives:
```
{'lnum': 0, 'script': 0, 'desc': 'LSP code lens', 'callback': 1886, 'noremap': 1, 'lhs': 'gc', 'mode': 'n', 'nowait': 0, 'expr': 0, 'sid': -8, 'buffer': 1, 'silent': 0}
```
Instead of `rhs` there is the `callback` entry.

This PR makes it print `<Lua function X>` as rhs, just like `nmap gc` outputs:
```
n  gc          *@<Lua function 1886>
                 LSP code lens
```