### PR TITLE
fix: neovim error in implicit convertion of Funcref to String

### DIFF
--- a/autoload/vm/maps.vim
+++ b/autoload/vm/maps.vim
@@ -260,7 +260,7 @@ fun! s:assign(plug, key, buffer, ...) abort
         if !empty(K) && K.buffer
             let b = 'b'.bufnr('%').': '
             " Handle Neovim mappings with Lua functions as rhs
-            let rhs = has_key(K, 'rhs') ? K.rhs : '<Lua function ' .. K.callback .. '>'
+            let rhs = has_key(K, 'rhs') ? K.rhs : string(K.callback)
             if m != 'i'
                 let s = b.'Could not map: '.k.' ('.a:plug.')  ->  ' . rhs
                 call add(b:VM_Debug.lines, s)


### PR DESCRIPTION
After https://github.com/neovim/neovim/issues/14090#issuecomment-1232924917 maparg() in Neovim returns the callback key as Funcref so explicit string conversion is needed. 

I also removed the additional `<Lua function X>` because now `string()` of a Funcref already returns some meaningful text (e.g. `function('<lambda>20')`), so the final warning message is e.g.
```
b3: Could not map: gc (gc)  ->  function('<lambda>20')
```

For users that are still using older Neovim everything should work, but the messages will be a bit worse, e.g.
before this PR:
```
b3: Could not map: gc (gc)  ->  <Lua function 1886>
```
and after:
```
b3: Could not map: gc (gc)  ->  1886
```
Still, I think that RHS doesn't tell much in either case, and it's LHS that is interesting.