### PR TITLE
fix #188: nunmap only if mapping exists

### DIFF
--- a/autoload/vm/ecmds2.vim
+++ b/autoload/vm/ecmds2.vim
@@ -89,7 +89,9 @@ fun! s:Edit.surround() abort
         endif
     endif
 
-    nunmap <buffer> S
+    if mapcheck('<buffer> S', 'n')
+        nunmap <buffer> S
+    endif
 
     call self.run_visual('S'.c, 1)
     if index(['[', '{', '('], c) >= 0

--- a/autoload/vm/ecmds2.vim
+++ b/autoload/vm/ecmds2.vim
@@ -89,9 +89,7 @@ fun! s:Edit.surround() abort
         endif
     endif
 
-    if mapcheck('<buffer> S', 'n')
-        nunmap <buffer> S
-    endif
+    silent! nunmap <buffer> S
 
     call self.run_visual('S'.c, 1)
     if index(['[', '{', '('], c) >= 0


### PR DESCRIPTION
Thank you for the great extension. I love this.
I fixed #188, preventing from calling `nunmap` if the mapping doesn't exist.
