### PR TITLE
Fix LunarWatcher/auto-pairs compatibility errors

### DIFF
--- a/autoload/vm/comp.vim
+++ b/autoload/vm/comp.vim
@@ -7,7 +7,7 @@ let s:plugins = extend({
             \   'disable': 'call ctrlsf#buf#ToggleMap(0)',
             \},
             \'AutoPairs': {
-            \   'test': { -> exists('b:autopairs_enabled') && b:autopairs_enabled },
+            \   'test': { -> exists('b:autopairs_enabled') && b:autopairs_enabled && exists('*AutoPairsTryInit') },
             \   'enable': 'unlet b:autopairs_loaded | call AutoPairsTryInit() | let b:autopairs_enabled = 1',
             \   'disable': 'let b:autopairs_enabled = 0',
             \},


### PR DESCRIPTION
LunarWatcher/auto-pairs is a maintained fork of jiangmiao/auto-pairs, which moves functions to autoload, so AutoPairsTryInit() does not exist.

This commit disables the compatibility hacks for this maintained fork, because they disable auto-pairs for the buffer and fail to re-enable it.

At a glance the fork seems to work ok with vim-visual-multi, at least it continues to complete pairs after using vim-visual-multi without calling autopairs#AutoPairsTryInit(), as long as b:autopairs_enabled is true.

There may well be some compatibility issues I'm not aware of, but these could be handled via a additional entry in the compatibility dictionary, or updating the existing entry to be aware of the maintained auto-pairs fork, while also being backwards compatible with the original plugin.