### PR TITLE
Allow custom keys for Surround

### DIFF
--- a/autoload/vm/ecmds2.vim
+++ b/autoload/vm/ecmds2.vim
@@ -89,9 +89,9 @@ fun! s:Edit.surround() abort
         endif
     endif
 
-    silent! nunmap <buffer> S
+    exe b:VM_mapping['Surround']['unmap']
 
-    call self.run_visual('S'.c, 1)
+    call self.run_visual(b:VM_mapping['Surround']['key'].c, 1)
     if index(['[', '{', '('], c) >= 0
         call map(s:v.W, 'v:val + 3')
     else
@@ -103,7 +103,7 @@ fun! s:Edit.surround() abort
         call self.post_process(0)
     endif
 
-    nmap <silent> <nowait> <buffer> S <Plug>(VM-Surround)
+    exe b:VM_mapping['Surround']['map']
 endfun
 
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
First, thanks for the plugin. I really love it.

## Motivation
I'm using the plugin https://github.com/echasnovski/mini.surround for surround and the current version of `vim-visual-multi` doesn't allow me to use the `mini.surround` default keys `sa`. The `vim-visual-multi` evaluates the key `S` to trigger the surround plugin.

## Proposed Solution

When calling the function `self.run_visual` use the configured keys for the `<Plug> VM-Surround` instead of the hard coded `S`.
https://github.com/mg979/vim-visual-multi/blob/b84a6d42c1c10678928b0bf8327f378c8bc8af5a/autoload/vm/ecmds2.vim#L94

To change this point I need a way to know what ware the configured keys for Surround, so my idea for this was change the behaviour of the function `Maps.build_buffer_maps()`. Instead of creating two lists with the commands to map and unmap, it will create a dictionary like: `{'PlugName': {'key': '', 'map': '', 'unmap': ''}}`. That way we can check what keys were used for the `plug` and access the map and unmap commands.

That change also allow us to have the same behaviour to map and unmap the plug instead of the hard coded lines:
https://github.com/mg979/vim-visual-multi/blob/b84a6d42c1c10678928b0bf8327f378c8bc8af5a/autoload/vm/ecmds2.vim#L106
https://github.com/mg979/vim-visual-multi/blob/b84a6d42c1c10678928b0bf8327f378c8bc8af5a/autoload/vm/ecmds2.vim#L92