### PR TITLE
fix: surround mapping

### DIFF
--- a/autoload/vm/ecmds2.vim
+++ b/autoload/vm/ecmds2.vim
@@ -89,21 +89,25 @@ fun! s:Edit.surround() abort
         endif
     endif
 
-    silent! nunmap <buffer> S
+    let S = g:Vm.maps.surround
 
-    call self.run_visual('S'.c, 1)
+    exe 'silent! nunmap <buffer> ' . S
+
+    call self.run_visual(S . c, 1)
+
     if index(['[', '{', '('], c) >= 0
         call map(s:v.W, 'v:val + 3')
     else
         call map(s:v.W, 'v:val + 1')
     endif
+
     if reselect
         call self.post_process(1, 0)
     else
         call self.post_process(0)
     endif
 
-    nmap <silent> <nowait> <buffer> S <Plug>(VM-Surround)
+    exe 'nmap <silent> <nowait> <buffer> ' . S . ' <Plug>(VM-Surround)'
 endfun
 
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/autoload/vm/maps.vim
+++ b/autoload/vm/maps.vim
@@ -173,6 +173,11 @@ fun! s:build_permanent_maps() abort
     for key in keys(maps)
         call add(g:Vm.unmaps, s:unmap(maps[key], 0))
     endfor
+
+    "store some mappings that need special handling
+    let g:Vm.maps.toggle   = get(g:VM_maps, 'Toggle Mappings', g:Vm.leader.buffer . '<Space>')
+    let g:Vm.maps.exit     = get(g:VM_maps, 'Exit', '<Esc>')
+    let g:Vm.maps.surround = get(g:VM_maps, 'Surround', 'S')
 endfun
 
 
@@ -231,12 +236,6 @@ fun! s:build_buffer_maps() abort
             unlet maps[key]
         endif
     endfor
-
-    "store the key used to toggle mappings
-    let g:Vm.maps.toggle = has_key(g:VM_maps, 'Toggle Mappings') ?
-                \ g:VM_maps['Toggle Mappings'] : g:Vm.leader.buffer . '<Space>'
-    let g:Vm.maps.exit   = has_key(g:VM_maps, 'Exit') ?
-                \ g:VM_maps['Exit'] : '<Esc>'
 
     "generate list of 'exe' commands for unmappings
     for key in keys(maps)


### PR DESCRIPTION
Alternative to #271.

The <plug>(VM-Surround) did nothing good, since the key was hardcoded for use with vim-surround. Now it will use the keys set in g:VM_maps['Surround'].
Using something else than vim-surround breaks surrounding with tags. From cursor mode `ys` is still hard-coded. Not much I can do about it for now (not worth to rethink all the mappings system just for this).