### PR TITLE
add Vimcasts and exercises to tutorial section

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ To run the tutorial:
 
     vim -Nu path/to/visual-multi/tutorialrc
 
+Vimcasts and exercises
+
+- [Advanced Multiline Editing in Neovim](https://www.youtube.com/watch?v=N-X_zjU5INs&t=555s) by [Andrew Courter](https://www.youtube.com/@ascourter)
+- [Multiline Editing in Neovim](https://www.youtube.com/watch?v=p4D8-brdrZo&t=98s) by [Andrew Courter](https://www.youtube.com/@ascourter)
+- [vim-visual-multi - Weekly (Neo)vim Plugin](https://www.youtube.com/watch?v=LhcnGU-COpo) by [CantuCodes](https://www.youtube.com/@cantucodes)
+- [vim-visual-multi-exercises](https://github.com/juanMarinero/vim-visual-multi-exercises) by [juanMarinero](https://github.com/juanMarinero)
+
 
 ### [Wiki](https://github.com/mg979/vim-visual-multi/wiki)
 


### PR DESCRIPTION
The [tutorialrc](https://github.com/mg979/vim-visual-multi/blob/master/tutorialrc) is very good. This PR is a **complement**.

I coded [vim-visual-multi-exercises](https://github.com/juanMarinero/vim-visual-multi-exercises) to apply [Learning-by-doing](https://en.wikipedia.org/wiki/Learning-by-doing), details how in this [FAQ](https://github.com/juanMarinero/vim-visual-multi-exercises?tab=readme-ov-file#why-is-needed-to-display-content-of-files-instead-of-writting-them-directly-on-readmemd).

This PR also provides some **vimcasts** that I think are quite useful for learning VM.

**Thanks** for this awesome plugin, and for your time!!

PD. **License**. I hope that my [vim-visual-multi-exercises](https://github.com/juanMarinero/vim-visual-multi-exercises#license) - [license](https://github.com/juanMarinero/vim-visual-multi-exercises#license) is right, compatible. If it's not, then I am sorry. Please guide me how to fix it. Thanks!